### PR TITLE
Removed min_/max_value from common configs.

### DIFF
--- a/devices/levoit-core300s/common.yaml
+++ b/devices/levoit-core300s/common.yaml
@@ -81,8 +81,6 @@ number:
     levoit: levoitcore300
     name: "Auto Mode Room Size"
     type: efficiency_room_size
-    min_value: 9
-    max_value: 50
   - platform: levoit
     levoit: levoitcore300
     name: "Filter Months"

--- a/devices/levoit-core400s/common.yaml
+++ b/devices/levoit-core400s/common.yaml
@@ -74,8 +74,6 @@ number:
     levoit: levoitcore400
     name: "Auto Mode Room Size"
     type: efficiency_room_size
-    min_value: 9
-    max_value: 83
   - platform: levoit
     levoit: levoitcore400
     name: "Filter Months"

--- a/devices/levoit-core600s/common.yaml
+++ b/devices/levoit-core600s/common.yaml
@@ -78,8 +78,6 @@ number:
     levoit: levoitcore600
     name: "Auto Mode Room Size"
     type: efficiency_room_size
-    min_value: 9
-    max_value: 147
   - platform: levoit
     levoit: levoitcore600
     name: "Filter Months"

--- a/devices/levoit-vital100s/common.yaml
+++ b/devices/levoit-vital100s/common.yaml
@@ -78,8 +78,6 @@ number:
     levoit: levoitvital100
     name: "Auto Mode Room Size"
     type: efficiency_room_size
-    min_value: 9
-    max_value: 52
   - platform: levoit
     levoit: levoitvital100
     name: "Filter Months"

--- a/devices/levoit-vital200s/common.yaml
+++ b/devices/levoit-vital200s/common.yaml
@@ -78,8 +78,6 @@ number:
     levoit: levoitvital200
     name: "Auto Mode Room Size"
     type: efficiency_room_size
-    min_value: 9
-    max_value: 87
   - platform: levoit
     levoit: levoitvital200
     name: "Filter Months"


### PR DESCRIPTION
I used the common configs to flash my C400S and C600S, but theses fields are invalid. It's possible/likely that they should still be clamped, but this makes these configs match the monolithic configs under `components/levoit` and they're working for me so far. I don't have much interest in using the room size mode, but I was able to set various room sizes fine.

Closes #19 