### PR TITLE
Added sample config for Core 600S with ESP32-SOLO-1C

### DIFF
--- a/devices/levoit-core600s/levoit-core600s-solo-1c.yaml
+++ b/devices/levoit-core600s/levoit-core600s-solo-1c.yaml
@@ -1,0 +1,17 @@
+# example levoit-core600s-solo-1c.yaml for flashing stock ESP32-SOLO-1C
+# !!! CHECK YOUR MODEL BEFORE FLASHING !!!
+# There have been sightings of multiple different ESP32s used in retail units.
+substitutions:
+  device_name: levoit-core600s-solo-1c
+  wifi_ap_ssid: free-levoit-Core600S
+  rx_pin: GPIO16
+  tx_pin: GPIO17
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+
+<<: !include common.yaml


### PR DESCRIPTION
Added a config for flashing the Core 600S with stock ESP32-SOLO-1C.