### PR TITLE
fix race condition where the led stays blinking even after conenction is restored

### DIFF
--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -630,6 +630,8 @@ namespace esphome
                         this->sendCommand(CommandType::setFilterLedOff);
                         filter_led_on_ = false;
                         filter_blinking_ = false;
+                        // Ensure any blinking is cleared before setting solid LED
+                        this->sendCommand(CommandType::setWifiLedOff);
                         if (this->model_ == ModelType::CORE200S)
                         {
                             this->set_timeout(500, [this]() {


### PR DESCRIPTION
i noticed that sometimes when the component looses connection (in my case 300s), and its restored afterwards, the led stays blinking until i restart. this seems to be due to  race condition .
this should fix the issue