### PR TITLE
Fix ESPHome fan preset deprecation warning

### DIFF
--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -72,7 +72,7 @@ namespace esphome
             // Construct traits
             this->traits_ =
                 fan::FanTraits(this->has_oscillating_, this->speed_count_ > 0, this->has_direction_, this->speed_count_);
-            this->traits_.set_supported_preset_modes(preset_modes);
+            this->set_supported_preset_modes(preset_modes);
     
      
         }

--- a/components/levoit/fan/levoit_fan.h
+++ b/components/levoit/fan/levoit_fan.h
@@ -15,8 +15,11 @@ class LevoitFan final : public Component, public fan::Fan {
   void dump_config() override;
   void set_parent(Levoit *parent) { parent_ = parent; }
   void set_speed_count(int count) { this->speed_count_ = count; }
-  void set_preset_modes(std::initializer_list<const char *> presets) { this->preset_modes_ = presets; }
-  fan::FanTraits get_traits() override { return this->traits_; }
+  void set_preset_modes(std::initializer_list<const char *> presets) { this->set_supported_preset_modes(presets); }
+  fan::FanTraits get_traits() override {
+    this->wire_preset_modes_(this->traits_);
+    return this->traits_;
+  }
 
   void apply_device_status(int power, int speed_level, int mode);
 
@@ -27,7 +30,6 @@ class LevoitFan final : public Component, public fan::Fan {
   bool has_direction_{false};
   int speed_count_{0};
   fan::FanTraits traits_;
-  std::vector<const char *> preset_modes_{};
   Levoit *parent_{nullptr};
 };
 


### PR DESCRIPTION
Use the current ESPHome Fan entity API for supported preset modes instead of registering them directly on `FanTraits`.

This keeps the existing fan trait construction for speed, speed count, oscillation, and direction, while wiring Fan-owned preset modes back into returned traits so Home Assistant still sees the supported presets.

Fixes #35

## Summary

- Replace deprecated `FanTraits::set_supported_preset_modes(...)` usage with `Fan::set_supported_preset_modes(...)`.
- Wire Fan-owned preset modes into `get_traits()` with ESPHome's current `wire_preset_modes_` pattern.
- Remove the unused local preset-mode vector.

## Validation

- `git diff --check` passed.
- Editor diagnostics reported no errors in the changed fan files.
- ESPHome 2026.5.0 local compile passed with a temporary Core400S config using the local component.
- ESPHome 2026.5.1 live build/install passed from `EdenNelson/levoit@fix/esphome-fan-preset-deprecation`.
- Build log scan found no fan preset deprecation warning, compiler warning, or build error.
- Core400S live smoke test passed: fan still exposes `Manual`, `Sleep`, and `Auto` presets, excludes `Pet`, and accepts Manual/Sleep/Auto preset changes.

## Disclosure

This PR was prepared with GitHub Copilot/AI assistance and human-in-the-loop review. Live validation was performed by a human on a Core400S using `air-purifier-office.yaml`. The change is intended to be API-only and should not alter fan behavior.