### PR TITLE
Correct Core400S CADR and Room Size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Auto mode options per model:
 |-------|---------|----------------|
 | C200S | — | up to 40 m² (430 ft²) |
 | C300S | Default / Quiet / Room Size | 9–50 m² (97–538 ft²) |
-| C400S | Default / Quiet / Room Size | 9–83 m² (97–894 ft²) |
+| C400S | Default / Quiet / Room Size | 9–38 m² (97–409 ft²) |
 | C600S | Default / Quiet / Room Size / ECO | 9–147 m² (97–1,582 ft²) |
 | V100S | Default / Quiet / Efficient | 9–52 m² (97–560 ft²) |
 | V200S | Default / Quiet / Efficient | 9–87 m² (97–936 ft²) |

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -461,7 +461,7 @@ namespace esphome
             if (model_ == ModelType::CORE300S)
                 cadr = 214; 
             if (model_ == ModelType::CORE400S)
-                cadr = 415;
+                cadr = 442;
             if (model_ == ModelType::CORE200S)
                 cadr = 167;
             if (model_ == ModelType::CORE600S)

--- a/devices/levoit-core400s/README.md
+++ b/devices/levoit-core400s/README.md
@@ -13,8 +13,8 @@ Started from community projects ([acvigue](https://github.com/acvigue/esphome-le
 | ESP Module | ESP32-SOLO-1C |
 | Board | CORE400S Ctrl V1.2 |
 | Fan Speeds | 4 |
-| CADR (spec) | 415 m³/h |
-| Room Size | 9–83 m² (97–894 ft²) |
+| CADR (spec) | 442 m³/h |
+| Room Size | 9–38 m² (97–409 ft²) |
 | ESPHome | 2026.1.2+ |
 | PM Sensor | PM2008MS  |
 
@@ -24,7 +24,7 @@ Started from community projects ([acvigue](https://github.com/acvigue/esphome-le
 |---------|------|-------|
 | Fan | fan | 4 speeds, presets: Manual / Auto / Sleep |
 | Auto Mode | select | Default / Quiet / Room Size |
-| Auto Mode Room Size | number | 9–83 m² |
+| Auto Mode Room Size | number | 9–38 m² |
 | Display | switch | Toggle LED display |
 | Child Lock | switch | |
 | PM2.5 | sensor | µg/m³ |

--- a/devices/levoit-core400s/common.yaml
+++ b/devices/levoit-core400s/common.yaml
@@ -60,6 +60,8 @@ number:
     levoit: levoitcore400
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 38
   - platform: levoit
     levoit: levoitcore400
     name: "Filter Months"

--- a/devices/levoit-core400s/levoit-core400s-builder-c3.yaml
+++ b/devices/levoit-core400s/levoit-core400s-builder-c3.yaml
@@ -84,6 +84,8 @@ number:
     levoit: levoitcore400
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 38
   - platform: levoit
     levoit: levoitcore400
     name: "Filter Months"

--- a/devices/levoit-core400s/levoit-core400s-builder-s3.yaml
+++ b/devices/levoit-core400s/levoit-core400s-builder-s3.yaml
@@ -84,6 +84,8 @@ number:
     levoit: levoitcore400
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 38
   - platform: levoit
     levoit: levoitcore400
     name: "Filter Months"

--- a/devices/levoit-core400s/levoit-core400s-builder.yaml
+++ b/devices/levoit-core400s/levoit-core400s-builder.yaml
@@ -81,6 +81,8 @@ number:
     levoit: levoitcore400
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 38
   - platform: levoit
     levoit: levoitcore400
     name: "Filter Months"


### PR DESCRIPTION
Correct the Core400S CADR constant and constrain the Core400S Auto Mode Room Size number to the documented model-specific range.

Fixes #37

## Summary

- Set Core400S CADR to `442 m³/h`.
- Update Core400S Room Size docs from `9-83 m²` / `97-894 ft²` to `9-38 m²` / `97-409 ft²`.
- Add Core400S `efficiency_room_size` YAML bounds: `min_value: 9` and `max_value: 38`.
- Update Core400S builder YAML mirrors and the root model table.

## Validation

- `git diff --check` passed.
- Editor diagnostics reported no errors in `components/levoit/levoit.cpp`.
- Targeted searches confirmed the Core400S corrected values and YAML bounds are present.
- ESPHome 2026.5.0 local Core400S compile passed against this branch.
- Compile warning scan still reports the existing fan preset API deprecation on clean upstream main; that warning is unrelated to this PR and is addressed separately in #36.
- Live stacked-branch validation on a Core400S passed using `EdenNelson/levoit@integration/core400s-auto-profile-stack`, which contains this change plus #36: ESPHome 2026.5.1 build/OTA succeeded and runtime reported `Current CADR` as `442 m³/h`.

## Follow-up

Live testing also showed an existing Core room-size decode round-trip issue: setting `9 m²` can echo as `8`, and setting `38 m²` can echo as `37`. That appears to be caused by decoded float room-size values being truncated through the current number publish path. This PR intentionally does not change Core room-size protocol encoding/decoding behavior; that belongs in a separate focused fix.

## Disclosure

This PR was prepared with GitHub Copilot/AI assistance and human-in-the-loop review. Live validation was performed by a human on a Core400S using `air-purifier-office.yaml`.