### PR TITLE
Fix Core Room Size encoding and decoded value round-trip

### DIFF
--- a/LEVOIT_UART.md
+++ b/LEVOIT_UART.md
@@ -361,7 +361,7 @@ Room sizes are transmitted as raw integer values derived from square feet.
 | Vital (tag `0x10`) | `raw = round(m² × 10.764 × 1.3)` | ESP→MCU |
 | Core / Core600S | `raw = round(m² × 10.764 × 3.15)` | ESP→MCU |
 
-Decode (MCU→ESP): `m² = raw / (10.764 × factor)` where factor = 1.3 (Vital) or 3.15 (Core).
+Decode (MCU→ESP): `m² = raw / (10.764 × factor)` where factor = 1.3 (Vital) or 3.15 (Core). Core status values are rounded to the nearest whole m² before publishing so values encoded with `round(m² × 10.764 × 3.15)` round-trip at range edges.
 
 ---
 

--- a/components/levoit/core_commands.cpp
+++ b/components/levoit/core_commands.cpp
@@ -2,6 +2,7 @@
 #include "levoit_message.h"
 #include "levoit.h"
 #include "number/levoit_number.h"
+#include "decoder_helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome
@@ -122,9 +123,8 @@ namespace esphome
                 auto *num = self->get_number(NumberType::EFFICIENCY_ROOM_SIZE);
                 if (num != nullptr)
                 {
-                    // Convert m² → raw MCU value: 1 m² = 10.764 sq ft, MCU uses sq_ft × 3.15
                     float m2 = num->state;
-                    uint32_t raw = static_cast<uint32_t>(m2 * 10.764f * 3.15f + 0.5f);
+                    uint32_t raw = encode_core_room_size_raw(m2);
                     uint8_t size_low = raw & 0xFF;
                     uint8_t size_high = (raw >> 8) & 0xFF;
 

--- a/components/levoit/core_status.cpp
+++ b/components/levoit/core_status.cpp
@@ -110,7 +110,7 @@ namespace esphome
         bool child_lock     = payload[14] != 0;
         uint8_t fan_auto_mode = payload[15];
         uint16_t efficency_area = (uint16_t)((payload[17] << 8) | payload[16]);
-        float efficency_area_m2 = static_cast<float>(efficency_area) / (10.764f * 3.15f);
+        float efficency_area_m2 = decode_core_room_size_m2(efficency_area);
         bool light_detect   = payload[21] != 0;
 
         self->publish_text_sensor(TextSensorType::ERROR_MESSAGE, "Ok");
@@ -144,7 +144,7 @@ namespace esphome
       bool child_lock = payload[13] != 0;
       uint8_t fan_auto_mode = payload[14];
       uint16_t efficency_area = (payload[16] << 8) | payload[15];
-      float efficency_area_m2 = static_cast<float>(efficency_area) / (10.764f * 3.15f);
+      float efficency_area_m2 = decode_core_room_size_m2(efficency_area);
       bool display_on = false;
       uint8_t fan_speed = 0;
       if (model == ModelType::CORE300S)

--- a/components/levoit/decoder_helpers.h
+++ b/components/levoit/decoder_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <cstdint>
+#include <cmath>
 
 namespace esphome
 {
@@ -34,6 +35,21 @@ namespace esphome
         return std::to_string(mins) + " min " + std::to_string(secs) + "s";
 
       return std::to_string(secs) + "s";
+    }
+
+    static inline float core_room_size_factor()
+    {
+      return 10.764f * 3.15f;
+    }
+
+    static inline uint32_t encode_core_room_size_raw(float m2)
+    {
+      return static_cast<uint32_t>(std::round(m2 * core_room_size_factor()));
+    }
+
+    static inline float decode_core_room_size_m2(uint16_t raw)
+    {
+      return std::round(static_cast<float>(raw) / core_room_size_factor());
     }
 
   } // namespace levoit

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -126,14 +126,13 @@ namespace esphome
 #endif
         }
 
-        void Levoit::publish_number(NumberType type, uint32_t value)
+        void Levoit::publish_number(NumberType type, float value)
         {
 #ifdef USE_NUMBER
             auto *nm = numbers_[nt_idx_(type)];
             if (!nm)
                 return;
-            float fvalue = static_cast<float>(value);
-            if (nm->has_state() && nm->state == fvalue)
+            if (nm->has_state() && nm->state == value)
                 return;
             nm->publish_state(value);
 #endif

--- a/components/levoit/levoit.h
+++ b/components/levoit/levoit.h
@@ -44,7 +44,7 @@ class Levoit : public Component, public uart::UARTDevice {
 
   // called by decoder when device reports status
   void publish_switch(SwitchType type, bool state);
-  void publish_number(NumberType type, uint32_t value);
+  void publish_number(NumberType type, float value);
   void publish_sensor(SensorType type, uint32_t value);
   void publish_select(SelectType type, uint32_t value);
   void publish_text_sensor(TextSensorType type, const std::string &value);


### PR DESCRIPTION
Fix Core-series Room Size encode/decode round-tripping so decoded status values publish the intended room-size value instead of truncating down at range edges.

Fixes #45

## Summary

- Add shared Core room-size helpers for the `10.764 * 3.15` factor.
- Encode Core Room Size raw values with `round(m² * 10.764 * 3.15)`.
- Decode Core Room Size status values with the same factor and round before publishing.
- Preserve float values in `publish_number(...)` instead of narrowing decoded number state to `uint32_t`.
- Document Core status rounding in `LEVOIT_UART.md`.

## Validation

- `git diff --check` passed.
- Editor diagnostics reported no errors in the changed source/header files.
- Sample math checks passed:
  - `9 m² -> raw=305 -> low=0x31 high=0x01 -> decoded=9`
  - `38 m² -> raw=1288 -> low=0x08 high=0x05 -> decoded=38`
- ESPHome Core400S local compile passed.
- Core400S live testing was performed from `EdenNelson/levoit@integration/core400s-auto-profile-stack`:
  - `38 m²` published as `38.00`, sent raw `1288` (`0x08 0x05`), and MCU status echoed `0x08 0x05` without the previous `37.00` bounce.
  - `9 m²` status echo showed raw `305` (`0x31 0x01`), which now decodes to `9` with the rounded Core status path; the previous bad behavior was `8.00`.

## Scope

This PR only changes Core room-size encoding/decoding and the numeric publish path needed to avoid truncating decoded number values. It does not add remembered Room Size persistence, fan mode mechanics, diagnostics, raw sensors, or unrelated model changes.

## Disclosure

This PR was prepared with GitHub Copilot/AI assistance and human-in-the-loop review. Live payload/status validation was performed by a human on a Core400S using `air-purifier-office.yaml`.