### PR TITLE
Keep fan mode in sync with speed and Auto Profile commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ The vent angle is set as a number entity (45° = nearly closed/upward, 90° = fu
 | Efficiency Counter | sensor | `efficiency_counter` | Seconds remaining at high fan speed in efficient auto mode **Vital only** |
 | Auto Mode High Fan Time | text_sensor | `auto_mode_room_size_high_fan` | Time still running at high speed in efficient auto mode, human readable **Vital only** |
 
+Auto Mode configures the purifier's automatic behavior and is distinct from the active fan preset/mode. On models with fan Auto support, changing Auto Mode enters the fan's Auto preset; direct fan speed changes switch the fan preset to Manual.
+
 Auto mode options per model:
 
 | Model | Options | Room Size Range |

--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -98,6 +98,7 @@ namespace esphome
             const bool cur_state = this->state;
             const int cur_speed = this->speed;
             esphome::StringRef cur_preset = this->get_preset_mode();
+            const auto preset = call.get_preset_mode();
 
             // ---- power ----
             if (call.get_state().has_value())
@@ -116,14 +117,17 @@ namespace esphome
                 int new_speed = *call.get_speed();
                 if (new_speed != cur_speed)
                 {
-                    //this->current_preset_ = "Manual"; // changing speed implies Manual mode
                     this->speed = new_speed;
                     speed_cmd = new_speed;
+                    if (preset == nullptr && (cur_preset.empty() || cur_preset != "Manual"))
+                    {
+                        this->set_preset_mode_("Manual");
+                        mode_cmd = preset_to_device_mode("Manual");
+                    }
                 }
             }
 
             // ---- preset/mode ----
-            const auto preset = call.get_preset_mode();
             if (preset != nullptr && (cur_preset.empty() || cur_preset != preset))
             {
                 // Sync base fan preset state

--- a/components/levoit/levoit.cpp
+++ b/components/levoit/levoit.cpp
@@ -48,6 +48,11 @@ namespace esphome
 
         static const char *const TAG = "levoit";
 
+        static bool supports_auto_fan_mode_(ModelType model)
+        {
+            return model != ModelType::CORE200S;
+        }
+
         // ===== Component =====
 
         void Levoit::register_switch(SwitchType type, LevoitSwitch *sw)
@@ -346,6 +351,8 @@ namespace esphome
 
             case NumberType::EFFICIENCY_ROOM_SIZE:
                 this->sendCommand(setAutoModeEfficient); // takes value from number: Room Size
+                if (supports_auto_fan_mode_(this->model_))
+                    this->sendCommand(setFanModeAuto);
                 break;
 
             case NumberType::SLEEP_MODE_MIN:
@@ -389,30 +396,42 @@ namespace esphome
             switch (type)
             {
             case SelectType::AUTO_MODE:
+            {
+                bool sent_auto_profile = false;
                 if (this->model_ == ModelType::EVERESTAIR)
                 {
                     // EverestAir options are {"Default"(idx0→mode0), "Eco"(idx1→mode3)}
                     this->sendCommand(value == 1 ? setAutoModeEco : setAutoModeDefault);
-                    break;
+                    sent_auto_profile = true;
                 }
-                switch (value)
+                else
                 {
-                case 0:
-                    this->sendCommand(setAutoModeDefault);
-                    break;
-                case 1:
-                    this->sendCommand(setAutoModeQuiet);
-                    break;
-                case 2:
-                    this->sendCommand(setAutoModeEfficient);
-                    break;
-                case 3:
-                    this->sendCommand(setAutoModeEco);
-                    break;
-                default:
-                    break;
+                    switch (value)
+                    {
+                    case 0:
+                        this->sendCommand(setAutoModeDefault);
+                        sent_auto_profile = true;
+                        break;
+                    case 1:
+                        this->sendCommand(setAutoModeQuiet);
+                        sent_auto_profile = true;
+                        break;
+                    case 2:
+                        this->sendCommand(setAutoModeEfficient);
+                        sent_auto_profile = true;
+                        break;
+                    case 3:
+                        this->sendCommand(setAutoModeEco);
+                        sent_auto_profile = true;
+                        break;
+                    default:
+                        break;
+                    }
                 }
+                if (sent_auto_profile && supports_auto_fan_mode_(this->model_))
+                    this->sendCommand(setFanModeAuto);
                 break;
+            }
 
             case SelectType::SLEEP_MODE:
                 switch (value)


### PR DESCRIPTION
Keep Home Assistant fan speed, fan preset/mode, and Auto Profile commands synchronized with the purifier's active fan mode.

Fixes #47

## Summary

- Direct fan speed changes now imply `Manual` fan mode when no explicit fan preset/mode is requested.
- Local fan preset state updates to `Manual` immediately when a direct speed change implies Manual mode.
- Auto Profile commands now send the selected profile command and then enter fan `Auto` mode on models that support fan Auto.
- Core200S is excluded from the follow-up fan Auto command because it does not support fan Auto mode.
- Document that Auto Mode configures automatic behavior and is distinct from the active fan preset/mode.

## Validation

- `git diff --check` passed.
- Editor diagnostics reported no errors in the changed files.
- ESPHome Core400S local compile passed.
- Core400S live testing was performed from `EdenNelson/levoit@integration/core400s-auto-profile-stack`, which stacked this branch with the active Core room-size round-trip test branch:
  - Home Assistant and the ESP32 Web UI stayed responsive and synchronized.
  - Direct fan speed and Auto Profile interactions behaved coherently with the expected state flow.
  - The remaining ESPHome Web UI limitation is display/control of fan preset mode itself, which is intentionally left to the separate Fan Operating Mode select enhancement.

## Scope

This PR keeps fan command mechanics focused on synchronized Manual/Auto behavior. It does not add a Fan Operating Mode select entity, remembered Room Size persistence, Core room-size encoding changes, diagnostics, raw sensors, generated YAML churn, or unrelated model changes.

## Disclosure

This PR was prepared with GitHub Copilot/AI assistance and human-in-the-loop review. Live validation was performed by a human on a Core400S using `air-purifier-office.yaml`.