### PR TITLE
fix(levoit): send speed command when leaving a preset at unchanged level

### DIFF
--- a/components/levoit/fan/levoit_fan.cpp
+++ b/components/levoit/fan/levoit_fan.cpp
@@ -115,7 +115,14 @@ namespace esphome
             if (call.get_speed().has_value() && (this->speed_count_ > 0))
             {
                 int new_speed = *call.get_speed();
-                if (new_speed != cur_speed)
+                // A speed call issued while a non-Manual preset is active must still
+                // be sent even if the level is unchanged: the operating mode changes.
+                // Sleep/Auto leave this->speed at its last manual value because the
+                // MCU reports no fan level for those modes (apply_device_status gets
+                // speed_level == -1), so "same level" is not "no change" here.
+                const bool leaving_preset =
+                    preset == nullptr && !cur_preset.empty() && cur_preset != "Manual";
+                if (new_speed != cur_speed || leaving_preset)
                 {
                     this->speed = new_speed;
                     speed_cmd = new_speed;


### PR DESCRIPTION
Setting the same fan level while Sleep/Auto is active was skipped by the speed
guard, so no UART command was sent and the device stayed in the preset. Treat a
speed call that leaves a non-Manual preset as a change.

Repro (Core 300S): Manual @ 100% → Sleep → set 100% again → nothing happens.

Cause: in Sleep/Auto the MCU reports no fan level, so `apply_device_status()`
gets `speed_level == -1` and `this->speed` stays stale. The next
`set_percentage(100)` looks like "no change" and is skipped.

Tested on a Core 300S: Sleep and Auto both fixed.